### PR TITLE
Simplify response functions

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -10,12 +10,10 @@ run({
     {
       url: '/api/return/:someId',
       method: 'GET',
-      response: async ({ query, params }) => {
+      response: ({ query, params }) => {
         return {
-          response: {
-            query,
-            params,
-          },
+          query,
+          params,
         };
       },
     },
@@ -24,10 +22,8 @@ run({
       method: 'POST',
       response: async ({ body, params }) => {
         return {
-          response: {
-            body,
-            params,
-          },
+          body,
+          params,
         };
       },
     },
@@ -64,12 +60,10 @@ run({
           operationName: 'Function',
           response: async ({ operationName, query, variables }) => {
             return {
-              response: {
-                data: {
-                  operationName,
-                  query,
-                  variables,
-                },
+              data: {
+                operationName,
+                query,
+                variables,
               },
             };
           },

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -88,6 +88,78 @@ describe('run', () => {
         server.kill(done);
       });
     });
+
+    it('can use functions for responses', done => {
+      const server = run({
+        default: [
+          {
+            url: '/test-function/:id',
+            method: 'POST',
+            response: ({ body, query, params }) => ({
+              body,
+              query,
+              params,
+            }),
+          },
+        ],
+      });
+
+      server.on('listening', async () => {
+        const id = 'some-id';
+        const testQuery = 'test-query';
+        const body = { some: 'body' };
+        const response = await rp.post(
+          `http://localhost:3000/test-function/${id}?testQuery=${testQuery}`,
+          { json: true, body },
+        );
+
+        safeExpect(server, response).toEqual({
+          body,
+          query: {
+            testQuery,
+          },
+          params: { id },
+        });
+
+        server.kill(done);
+      });
+    });
+
+    it('can use async functions for responses', done => {
+      const server = run({
+        default: [
+          {
+            url: '/test-function/:id',
+            method: 'POST',
+            response: async ({ body, query, params }) => ({
+              body,
+              query,
+              params,
+            }),
+          },
+        ],
+      });
+
+      server.on('listening', async () => {
+        const id = 'some-id';
+        const testQuery = 'test-query';
+        const body = { some: 'body' };
+        const response = await rp.post(
+          `http://localhost:3000/test-function/${id}?testQuery=${testQuery}`,
+          { json: true, body },
+        );
+
+        safeExpect(server, response).toEqual({
+          body,
+          query: {
+            testQuery,
+          },
+          params: { id },
+        });
+
+        server.kill(done);
+      });
+    });
   });
 
   describe('scenarios', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,13 +9,18 @@ export type Scenarios = {
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
+export type Override<TResponse> = {
+  __override: {
+    response: TResponse;
+    responseCode?: number;
+    responseHeaders?: Record<string, string>;
+    delay?: number;
+  };
+};
+
 export type ResponseFunction<TResponse, TInput> = (
   input: TInput,
-) => Promise<{
-  response: TResponse;
-  responseHeaders?: Record<string, string>;
-  responseCode?: number;
-}>;
+) => TResponse | Override<TResponse> | Promise<TResponse | Override<TResponse>>;
 
 export type MockResponse<TResponse, TInput> =
   | TResponse


### PR DESCRIPTION
Response functions no longer have to be async. For the majority of cases the response does not need
to be nested on an object with a response property. More advanced cases now need to use __override
when responseCode, responseHeaders or delay needs to be customised within the same response
function.

BREAKING CHANGE: The return object for response functions do not use a nested object with a response
property any more. The solution is to either remove the nested response or for more advanced use
cases to nest under a further __override property.