### PR TITLE
feat: allow response to be empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 |----------|------|---------|-------------|
 | url | `string` / `RegExp` | _required_ | Path of endpoint. Must start with `/`. |
 | method | `'GET'` / `'POST'` / `'PUT'` / `'DELETE'` | _required_ | HTTP method of endpoint. |
-| response | `string` / `object` / `HttpResponseFunction` | _required_ | JSON response for endpoint. [HttpResponseFunction](#httpresponsefunction). |
+| response | `undefined` / `null` / `string` / `object` / `HttpResponseFunction` | `undefined` | Response for endpoint. [HttpResponseFunction](#httpresponsefunction). |
 | responseCode | `number` | `200` | HTTP status code for response. |
-| responseHeaders | `object` / `undefined` | `undefined` | Key/value pairs of HTTP headers for response. |
+| responseHeaders | `object` / `undefined` | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
 | responseDelay | `number` | `0` | Number of milliseconds before the response is returned. |
 
 ### HttpResponseFunction
@@ -127,7 +127,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 | query | `object` | `{}` | query object as defined by `express`. |
 | body | `object` | `{}` | body object as defined by `express`. |
 | params | `object` | `{}` | params object as defined by `express`. |
-| response | `string` / `object` / `Override` | _required_ | JSON response. [Override](#override). |
+| response | `undefined` / `null` / `string` / `object` / `Override` | _required_ | Response. [Override](#override). |
 
 ### GraphQlMock
 
@@ -151,9 +151,9 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 |----------|------|---------|-------------|
 | type | `'query'` / `'mutation'` | _required_ | Type of operation. |
 | name | `string` | _required_ | Name of operation. |
-| response | `{ data?: null / object, errors?: array }` / `object` / `GraphQlResponseFunction` | _required_ | GraphQL response. `object` should only be used when combined with a 5XX `responseCode` to simulate an HTTP transport failure. [GraphQlResponseFunction](#graphqlresponsefunction). |
+| response | `{ data?: null / object, errors?: array }` / `object` / `string` / `null` / `undefined` / `GraphQlResponseFunction` | `undefined` | GraphQL response. `object` / `string` / `null` / `undefined` should be used when simulating non GraphQL responses. [GraphQlResponseFunction](#graphqlresponsefunction). |
 | responseCode | `number` | `200` | HTTP status code for response. |
-| responseHeaders | `object` / `undefined` | `undefined` | Key/value pairs of HTTP headers for response. |
+| responseHeaders | `object` / `undefined` | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
 | responseDelay | `number` | `0` | Number of milliseconds before the response is returned. |
 
 ### GraphQlResponseFunction
@@ -167,7 +167,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 | operationName | `string` | `''` | operationName sent by client. |
 | query | `string` | `''` | GraphQL query. |
 | variables | `object` | `{}` | variables sent by client. |
-| response | `{ data: object, errors?: array }` / `object` / `Override` | _required_ | Standard GraphQL JSON response. `object` should only be used when combined with a 5XX `responseCode` to simulate an HTTP transport failure. [Override](#override). |
+| response | `{ data: object, errors?: array }` / `object` / `string` / `null` / `undefined` / `Override` | _required_ | GraphQL response. `object` / `string` / `null` / `undefined` should be used when simulating non GraphQL responses. [Override](#override). |
 
 ### Override
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -255,6 +255,115 @@ describe('run', () => {
         expect(response).toEqual(expectedResponse);
       });
     });
+
+    it('allows empty responses', () => {
+      const server = run({
+        default: [
+          {
+            url: '/api/test',
+            method: 'GET',
+          },
+        ],
+      });
+
+      return serverTest(server, async () => {
+        const response = await rp.get(`http://localhost:3000/api/test`, {
+          resolveWithFullResponse: true,
+        });
+
+        expect(response.body).toEqual('');
+        expect(response.headers['content-type']).toBeUndefined();
+      });
+    });
+
+    it('allows null responses', () => {
+      const server = run({
+        default: [
+          {
+            url: '/api/test',
+            method: 'GET',
+            response: null,
+          },
+        ],
+      });
+
+      return serverTest(server, async () => {
+        const response = await rp.get(`http://localhost:3000/api/test`, {
+          json: true,
+        });
+
+        expect(response).toBeNull();
+      });
+    });
+
+    it('adds application/json content-type when response is not undefined', () => {
+      const server = run({
+        default: [
+          {
+            url: '/api/test',
+            method: 'GET',
+            response: {},
+          },
+        ],
+      });
+
+      return serverTest(server, async () => {
+        const response = await rp.get(`http://localhost:3000/api/test`, {
+          resolveWithFullResponse: true,
+          json: true,
+        });
+
+        expect(response.headers['content-type']).toContain('application/json');
+      });
+    });
+
+    it('adds application/json content-type when response is not undefined and responseHeaders does not contain content-type', () => {
+      const server = run({
+        default: [
+          {
+            url: '/api/test',
+            method: 'GET',
+            response: {},
+            responseHeaders: {
+              'Made-Up': 'Header',
+            },
+          },
+        ],
+      });
+
+      return serverTest(server, async () => {
+        const response = await rp.get(`http://localhost:3000/api/test`, {
+          resolveWithFullResponse: true,
+          json: true,
+        });
+
+        expect(response.headers['made-up']).toEqual('Header');
+        expect(response.headers['content-type']).toContain('application/json');
+      });
+    });
+
+    it('does not add application/json content-type when content-type is already defined', () => {
+      const server = run({
+        default: [
+          {
+            url: '/api/test',
+            method: 'GET',
+            response: {},
+            responseHeaders: {
+              'Content-Type': 'text/*',
+            },
+          },
+        ],
+      });
+
+      return serverTest(server, async () => {
+        const response = await rp.get(`http://localhost:3000/api/test`, {
+          resolveWithFullResponse: true,
+        });
+
+        expect(response.headers['content-type']).toContain('text/*');
+      });
+    });
   });
 
   describe('scenarios', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,12 +10,7 @@ export type Scenarios = {
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export type Override<TResponse> = {
-  __override: {
-    response: TResponse;
-    responseCode?: number;
-    responseHeaders?: Record<string, string>;
-    responseDelay?: number;
-  };
+  __override: ResponseProps<TResponse>;
 };
 
 export type ResponseFunction<TInput, TResponse> = (
@@ -26,21 +21,28 @@ export type MockResponse<TInput, TResponse> =
   | TResponse
   | ResponseFunction<TInput, TResponse>;
 
+export type HttpResponse = Record<string, any> | string | null;
+
+export type ResponseProps<TResponse> = {
+  response?: TResponse;
+  responseCode?: number;
+  responseHeaders?: Record<string, string>;
+  responseDelay?: number;
+};
+
 export type HttpMock = {
   url: string | RegExp;
   method: HttpMethod;
-  response: MockResponse<
+} & ResponseProps<
+  MockResponse<
     {
       query: Record<string, string | Array<string>>;
       body: Record<string, any>;
       params: Record<string, string>;
     },
-    Record<string, any> | string
-  >;
-  responseCode?: number;
-  responseHeaders?: Record<string, string>;
-  responseDelay?: number;
-};
+    HttpResponse
+  >
+>;
 
 export type GraphQlResponse = {
   data?: null | Record<string, any>;
@@ -50,18 +52,16 @@ export type GraphQlResponse = {
 export type Operation = {
   type: 'query' | 'mutation';
   name: string;
-  response: MockResponse<
+} & ResponseProps<
+  MockResponse<
     {
       operationName: string;
       query: string;
       variables: Record<string, any>;
     },
-    GraphQlResponse | Record<string, any>
-  >;
-  responseCode?: number;
-  responseHeaders?: Record<string, string>;
-  responseDelay?: number;
-};
+    GraphQlResponse | HttpResponse
+  >
+>;
 
 export type GraphQlMock = {
   url: string;


### PR DESCRIPTION
As well as allowing the response to be null or empty, the response will automatically be sent back
as json when the response is not defined and the content-type has not been set to something else