### PR TITLE
feat: extended updateContext so that it can also accept a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 ### HttpResponseFunction
 
-> `function({ query, body, params, context, updateContext, getContext }): response | Promise<response>`
+> `function({ query, body, params, context, updateContext }): response | Promise<response>`
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
@@ -142,8 +142,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 | body | `object` | `{}` | body object as defined by `express`. |
 | params | `object` | `{}` | params object as defined by `express`. |
 | context | `object` | `{}` | Data stored across API calls. |
-| updateContext | `Function` | `partialContext => updatedContext` | Used to update context. |
-| getContext | `Function` | `() => context` | Used to get the latest context. |
+| updateContext | `Function` | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`).  |
 | response | `undefined` / `Response` / `Override` | _required_ | [Response](#response), [Override](#override). |
 
 ### GraphQlMock
@@ -179,7 +178,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 ### GraphQlResponseFunction
 
-> `function({ variables, context, updateContext, getContext }): response | Promise<response>`
+> `function({ variables, context, updateContext }): response | Promise<response>`
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
@@ -187,8 +186,7 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 |----------|------|---------|-------------|
 | variables | `object` | `{}` | variables sent by client. |
 | context | `object` | `{}` | Data stored across API calls. |
-| updateContext | `Function` | `partialContext => updatedContext` | Used to update context. |
-| getContext | `Function` | `() => context` | Used to get the latest context. |
+| updateContext | `Function` | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`).  |
 | response | `undefined` / `Response` / `GraphQlResponse` / `Override` | _required_ | [Response](#response), [GraphQlResponse](#graphqlresponse), [Override](#override). |
 
 ### Override

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,8 +126,15 @@ function createRouter({
 
   return router;
 
-  function updateContext(partialContext: Context) {
-    context = { ...context, ...partialContext };
+  function updateContext(
+    partialContext: Context | ((context: Context) => Context),
+  ) {
+    context = {
+      ...context,
+      ...(typeof partialContext === 'function'
+        ? partialContext(context)
+        : partialContext),
+    };
 
     return context;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,4 +89,6 @@ export type Options = {
 
 export type Context = Record<string, any>;
 
-export type UpdateContext = (partialContext: Context) => Context;
+export type UpdateContext = (
+  partialContext: Context | ((context: Context) => Context),
+) => Context;


### PR DESCRIPTION
The updateContext function passed to response handlers used to only accept a partial context object,
which merges into the context object. It now also accepts a function. This function will be passed
the current context and should return a partial object which will be merged into the context object.
This is to enable async processes like setTimeout to access the most up to date context.