### PR TITLE
improvement: improve how responses return status, headers, data and how the delay is decided

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ run({
     {
       url: '/api/test-me',
       method: 'GET',
-      response: { blue: 'yoyo' },
+      response: { data: { blue: 'yoyo' } },
     },
   ],
   scenarios: {
@@ -48,7 +48,7 @@ run({
       {
         url: '/api/test-me',
         method: 'GET',
-        response: { blue: 'cheese' },
+        response: { data: { blue: 'cheese' } },
       },
     ],
   },
@@ -123,22 +123,26 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 ### HttpMock
 
-> `{ url, method, response, responseCode, responseHeaders, responseDelay }`
+> `{ url, method, response }`
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
-| Property        | Type                                                  | Default         | Description                                                                                                                                                                                                        |
-| --------------- | ----------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| url             | `string` / `RegExp`                                   | _required_      | Path of endpoint. Must start with `/`.                                                                                                                                                                             |
-| method          | `'GET'` / `'POST'` / `'PUT'` / `'DELETE'` / `'PATCH'` | _required_      | HTTP method of endpoint.                                                                                                                                                                                           |
-| response        | `undefined` / `Response` / `HttpResponseFunction`     | `undefined`     | [Response](#response), [HttpResponseFunction](#httpresponsefunction).                                                                                                                                              |
-| responseCode    | `number`                                              | `200`           | HTTP status code for response.                                                                                                                                                                                     |
-| responseHeaders | `object` / `undefined`                                | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
-| responseDelay   | `number`                                              | `0`             | Number of milliseconds before the response is returned.                                                                                                                                                            |
+| Property | Type                                                  | Default     | Description                                                           |
+| -------- | ----------------------------------------------------- | ----------- | --------------------------------------------------------------------- |
+| url      | `string` / `RegExp`                                   | _required_  | Path of endpoint. Must start with `/`.                                |
+| method   | `'GET'` / `'POST'` / `'PUT'` / `'DELETE'` / `'PATCH'` | _required_  | HTTP method of endpoint.                                              |
+| response | `undefined` / `Response` / `HttpResponseFunction`     | `undefined` | [Response](#response), [HttpResponseFunction](#httpresponsefunction). |
 
 ### Response
 
-> `null` / `string` / `object`
+> `{ status, headers, data, delay }`
+
+| Property | Type                         | Default         | Description                                                                                                                                                                                                        |
+| -------- | ---------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| status   | `number`                     | `200`           | HTTP status code for response.                                                                                                                                                                                     |
+| headers  | `object` / `undefined`       | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
+| data     | `null` / `string` / `object` | `undefined`     | Response data                                                                                                                                                                                                      |
+| delay    | `number`                     | `0`             | Number of milliseconds before the response is returned.                                                                                                                                                            |
 
 ### HttpResponseFunction
 
@@ -146,14 +150,14 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
-| Property      | Type                                  | Default                            | Description                                                                                                       |
-| ------------- | ------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| query         | `object`                              | `{}`                               | query object as defined by `express`.                                                                             |
-| body          | `object`                              | `{}`                               | body object as defined by `express`.                                                                              |
-| params        | `object`                              | `{}`                               | params object as defined by `express`.                                                                            |
-| context       | `object`                              | `{}`                               | Data stored across API calls.                                                                                     |
-| updateContext | `Function`                            | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`). |
-| response      | `undefined` / `Response` / `Override` | _required_                         | [Response](#response), [Override](#override).                                                                     |
+| Property      | Type                     | Default                            | Description                                                                                                       |
+| ------------- | ------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| query         | `object`                 | `{}`                               | query object as defined by `express`.                                                                             |
+| body          | `object`                 | `{}`                               | body object as defined by `express`.                                                                              |
+| params        | `object`                 | `{}`                               | params object as defined by `express`.                                                                            |
+| context       | `object`                 | `{}`                               | Data stored across API calls.                                                                                     |
+| updateContext | `Function`               | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`). |
+| response      | `undefined` / `Response` | _required_                         | [Response](#response).                                                                                            |
 
 ### GraphQlMock
 
@@ -169,22 +173,26 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 #### Operation
 
-> `{ type, name, response, responseCode, responseHeaders, responseDelay }`
+> `{ type, name, response }`
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
-| Property        | Type                                                                     | Default         | Description                                                                                                                                                                                                        |
-| --------------- | ------------------------------------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| type            | `'query'` / `'mutation'`                                                 | _required_      | Type of operation.                                                                                                                                                                                                 |
-| name            | `string`                                                                 | _required_      | Name of operation.                                                                                                                                                                                                 |
-| response        | `undefined` / `Response` / `GraphQlResponse` / `GraphQlResponseFunction` | `undefined`     | [Response](#response), [GraphQlResponse](#graphqlresponse), [GraphQlResponseFunction](#graphqlresponsefunction).                                                                                                   |
-| responseCode    | `number`                                                                 | `200`           | HTTP status code for response.                                                                                                                                                                                     |
-| responseHeaders | `object` / `undefined`                                                   | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
-| responseDelay   | `number`                                                                 | `0`             | Number of milliseconds before the response is returned.                                                                                                                                                            |
+| Property | Type                                                        | Default     | Description                                                                               |
+| -------- | ----------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| type     | `'query'` / `'mutation'`                                    | _required_  | Type of operation.                                                                        |
+| name     | `string`                                                    | _required_  | Name of operation.                                                                        |
+| response | `undefined` / `GraphQlResponse` / `GraphQlResponseFunction` | `undefined` | [GraphQlResponse](#graphqlresponse), [GraphQlResponseFunction](#graphqlresponsefunction). |
 
 ### GraphQlResponse
 
-> `{ data?: null / object, errors?: array }`
+> `{ status, headers, data, delay }`
+
+| Property | Type                                       | Default         | Description                                                                                                                                                                                                        |
+| -------- | ------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| status   | `number`                                   | `200`           | HTTP status code for response.                                                                                                                                                                                     |
+| headers  | `object` / `undefined`                     | See description | Key/value pairs of HTTP headers for response. Defaults to `undefined` when response is `undefined`, adds `'Content-Type': 'application/json'` when response is not `undefined` and `Content-Type` is not supplied. |
+| data     | `{ data?: null / object, errors?: array }` | `undefined`     | Response data                                                                                                                                                                                                      |
+| delay    | `number`                                   | `0`             | Number of milliseconds before the response is returned.                                                                                                                                                            |
 
 ### GraphQlResponseFunction
 
@@ -192,18 +200,16 @@ See [HttpMock](#httpmock) and [GraphQlMock](#graphqlmock) for more details.
 
 <!-- https://www.tablesgenerator.com/markdown_tables -->
 
-| Property      | Type                                                      | Default                            | Description                                                                                                       |
-| ------------- | --------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| variables     | `object`                                                  | `{}`                               | variables sent by client.                                                                                         |
-| context       | `object`                                                  | `{}`                               | Data stored across API calls.                                                                                     |
-| updateContext | `Function`                                                | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`). |
-| response      | `undefined` / `Response` / `GraphQlResponse` / `Override` | _required_                         | [Response](#response), [GraphQlResponse](#graphqlresponse), [Override](#override).                                |
+| Property      | Type                            | Default                            | Description                                                                                                       |
+| ------------- | ------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| variables     | `object`                        | `{}`                               | variables sent by client.                                                                                         |
+| context       | `object`                        | `{}`                               | Data stored across API calls.                                                                                     |
+| updateContext | `Function`                      | `partialContext => updatedContext` | Used to update context. `partialContext` can either be an `object` or a function (`context` => `partialContext`). |
+| response      | `undefined` / `GraphQlResponse` | _required_                         | [GraphQlResponse](#graphqlresponse).                                                                              |
 
-### Override
+### Allowing for multiple responses
 
-> `{ __override: { response, responseCode, responseHeaders, responseDelay } }`
-
-Sometimes you may want an endpoint to respond with different status codes depending on what is sent. It is the recommendation of this package that this can be achieved by using scenarios. However, as an escape hatch you can override `responseCode`, `responseHeaders` and `responseDelay` by using the `__override` property:
+Sometimes you may want an endpoint to respond with different status codes depending on what is sent. It is the recommendation of this package that this can be achieved by using scenarios. However, given `response` can be a function, it is possible to respond with a different value for the `status`, `headers`, `data` and `delay` properties:
 
 ```javascript
 const mock = {
@@ -212,35 +218,29 @@ const mock = {
   response: ({ body }) => {
     if (body.name === 'error1') {
       return {
-        __override: {
-          response: { message: 'something went wrong' },
-          responseCode: 400,
-          responseDelay: 1000,
-        },
+        status: 400,
+        data: { message: 'something went wrong' },
+        delay: 1000,
       };
     }
 
     if (body.name === 'error2') {
       return {
-        __override: {
-          response: { message: 'something else went wrong' },
-          responseCode: 500,
-          responseDelay: 2000,
-        },
+        status: 500,
+        data: { message: 'something else went wrong' },
+        delay: 2000,
       };
     }
 
     if (body.name === 'notFound') {
       return {
-        __override: {
-          response: { message: 'no data here' },
-          responseCode: 404,
-        },
+        status: 404,
+        data: { message: 'no data here' },
       };
     }
 
-    // No __override necessary, this is the response on success
-    return { message: 'success' };
+    // Default status is 200
+    return { data: { message: 'success' } };
   },
 };
 ```

--- a/example/index.ts
+++ b/example/index.ts
@@ -11,15 +11,17 @@ run({
       {
         url: '/api/test-me',
         method: 'GET',
-        response: { blue: 'yoyo' },
+        response: { data: { blue: 'yoyo' } },
       },
       {
         url: '/api/return/:someId',
         method: 'GET',
         response: ({ query, params }) => {
           return {
-            query,
-            params,
+            data: {
+              query,
+              params,
+            },
           };
         },
       },
@@ -28,8 +30,10 @@ run({
         method: 'POST',
         response: async ({ body, params }) => {
           return {
-            body,
-            params,
+            data: {
+              body,
+              params,
+            },
           };
         },
       },
@@ -42,7 +46,9 @@ run({
             name: 'Cheese',
             response: {
               data: {
-                name: 'Cheddar',
+                data: {
+                  name: 'Cheddar',
+                },
               },
             },
           },
@@ -51,7 +57,9 @@ run({
             name: 'Bread',
             response: {
               data: {
-                name: 'Bread Roll',
+                data: {
+                  name: 'Bread Roll',
+                },
               },
             },
           },
@@ -67,7 +75,9 @@ run({
             response: async ({ variables }) => {
               return {
                 data: {
-                  variables,
+                  data: {
+                    variables,
+                  },
                 },
               };
             },
@@ -77,12 +87,12 @@ run({
       {
         url: '/api/context',
         method: 'GET',
-        response: ({ context }) => context,
+        response: ({ context }) => ({ data: context }),
       },
       {
         url: '/api/context',
         method: 'PUT',
-        response: ({ body, updateContext }) => updateContext(body),
+        response: ({ body, updateContext }) => ({ data: updateContext(body) }),
       },
     ],
   },
@@ -93,7 +103,7 @@ run({
         {
           url: '/api/test-me',
           method: 'GET',
-          response: { blue: 'cheese' },
+          response: { data: { blue: 'cheese' } },
         },
         {
           url: '/api/graphql',
@@ -104,7 +114,9 @@ run({
               name: 'Cheese',
               response: {
                 data: {
-                  name: 'Blue Cheese',
+                  data: {
+                    name: 'Blue Cheese',
+                  },
                 },
               },
             },
@@ -118,7 +130,7 @@ run({
         {
           url: '/api/test-me',
           method: 'GET',
-          response: { red: 'leicester' },
+          response: { data: { red: 'leicester' } },
         },
         {
           url: '/api/graphql',
@@ -129,7 +141,9 @@ run({
               name: 'Cheese',
               response: {
                 data: {
-                  name: 'Red Leicester',
+                  data: {
+                    name: 'Red Leicester',
+                  },
                 },
               },
             },
@@ -149,7 +163,7 @@ run({
       {
         url: '/api/test-me-2',
         method: 'GET',
-        response: { blue: 'tang' },
+        response: { data: { blue: 'tang' } },
       },
     ],
     water: [],

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -82,27 +82,27 @@ describe('run', () => {
           {
             url: '/test-me',
             method: 'GET',
-            response: expectedGetResponse,
+            response: { data: expectedGetResponse },
           },
           {
             url: '/test-me',
             method: 'POST',
-            response: expectedPostResponse,
+            response: { data: expectedPostResponse },
           },
           {
             url: '/test-me',
             method: 'PUT',
-            response: expectedPutResponse,
+            response: { data: expectedPutResponse },
           },
           {
             url: '/test-me',
             method: 'DELETE',
-            response: expectedDeleteResponse,
+            response: { data: expectedDeleteResponse },
           },
           {
             url: '/test-me',
             method: 'PATCH',
-            response: expectedPatchResponse,
+            response: { data: expectedPatchResponse },
           },
         ],
       });
@@ -137,8 +137,9 @@ describe('run', () => {
           {
             url: '/test-me',
             method: 'GET',
-            responseDelay,
-            response: {},
+            response: {
+              delay: responseDelay,
+            },
           },
         ],
       });
@@ -163,9 +164,11 @@ describe('run', () => {
             url: '/test-function/:id',
             method: 'POST',
             response: ({ body, query, params }) => ({
-              body,
-              query,
-              params,
+              data: {
+                body,
+                query,
+                params,
+              },
             }),
           },
         ],
@@ -197,9 +200,11 @@ describe('run', () => {
             url: '/test-function/:id',
             method: 'POST',
             response: async ({ body, query, params }) => ({
-              body,
-              query,
-              params,
+              data: {
+                body,
+                query,
+                params,
+              },
             }),
           },
         ],
@@ -239,7 +244,7 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'Person',
-                response: expectedResponse,
+                response: { data: expectedResponse },
               },
             ],
           },
@@ -281,7 +286,9 @@ describe('run', () => {
                 name: 'Person',
                 response: ({ variables }) => ({
                   data: {
-                    variables,
+                    data: {
+                      variables,
+                    },
                   },
                 }),
               },
@@ -325,7 +332,7 @@ describe('run', () => {
               {
                 type: 'query',
                 name: operationName,
-                response: expectedResponse,
+                response: { data: expectedResponse },
               },
             ],
           },
@@ -364,7 +371,7 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'Person',
-                response: expectedResponse,
+                response: { data: expectedResponse },
               },
             ],
           },
@@ -406,7 +413,9 @@ describe('run', () => {
                 name: 'Person',
                 response: ({ variables }) => ({
                   data: {
-                    variables,
+                    data: {
+                      variables,
+                    },
                   },
                 }),
               },
@@ -449,7 +458,7 @@ describe('run', () => {
               {
                 type: 'query',
                 name: operationName,
-                response: expectedResponse,
+                response: { data: expectedResponse },
               },
             ],
           },
@@ -484,7 +493,6 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'Query',
-                response: {},
               },
             ],
           },
@@ -532,12 +540,12 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'User',
-                response: expectedResponse1,
+                response: { data: expectedResponse1 },
               },
               {
                 type: 'mutation',
                 name: 'User',
-                response: expectedResponse2,
+                response: { data: expectedResponse2 },
               },
             ],
           },
@@ -583,7 +591,7 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'GetUser',
-                response: expectedResponse,
+                response: { data: expectedResponse },
               },
             ],
           },
@@ -631,8 +639,10 @@ describe('run', () => {
                 name: 'GetAccount',
                 response: {
                   data: {
-                    account: {
-                      id: '111222',
+                    data: {
+                      account: {
+                        id: '111222',
+                      },
                     },
                   },
                 },
@@ -705,12 +715,12 @@ describe('run', () => {
               {
                 type: 'query',
                 name: 'GetAccount',
-                response: { data: { account: { id: '333444' } } },
+                response: { data: { data: { account: { id: '333444' } } } },
               },
               {
                 type: 'query',
                 name: 'GetUser',
-                response: { data: { user: { name: 'Holly' } } },
+                response: { data: { data: { user: { name: 'Holly' } } } },
               },
             ],
           },
@@ -765,7 +775,7 @@ describe('run', () => {
           {
             url: '/api/test',
             method: 'GET',
-            response: null,
+            response: { data: null },
           },
         ],
       });
@@ -785,7 +795,7 @@ describe('run', () => {
           {
             url: '/api/test',
             method: 'GET',
-            response: {},
+            response: { data: {} },
           },
         ],
       });
@@ -806,9 +816,11 @@ describe('run', () => {
           {
             url: '/api/test',
             method: 'GET',
-            response: {},
-            responseHeaders: {
-              'Made-Up': 'Header',
+            response: {
+              data: {},
+              headers: {
+                'Made-Up': 'Header',
+              },
             },
           },
         ],
@@ -831,9 +843,10 @@ describe('run', () => {
           {
             url: '/api/test',
             method: 'GET',
-            response: {},
-            responseHeaders: {
-              'Content-Type': 'text/*',
+            response: {
+              headers: {
+                'Content-Type': 'text/*',
+              },
             },
           },
         ],
@@ -859,7 +872,7 @@ describe('run', () => {
             {
               url: '/user',
               method: 'GET',
-              response: ({ context }) => context.name,
+              response: ({ context }) => ({ data: context.name }),
             },
             {
               url: '/user',
@@ -867,7 +880,7 @@ describe('run', () => {
               response: ({ body: { name }, updateContext }) => {
                 updateContext({ name });
 
-                return name;
+                return { data: name };
               },
             },
           ],
@@ -905,7 +918,7 @@ describe('run', () => {
             {
               url: '/info',
               method: 'GET',
-              response: ({ context }) => context,
+              response: ({ context }) => ({ data: context }),
             },
             {
               url: '/user',
@@ -913,7 +926,7 @@ describe('run', () => {
               response: ({ body: { name }, updateContext }) => {
                 updateContext({ name });
 
-                return name;
+                return { data: name };
               },
             },
           ],
@@ -953,7 +966,7 @@ describe('run', () => {
             {
               url: '/info',
               method: 'GET',
-              response: ({ context }) => context,
+              response: ({ context }) => ({ data: context }),
             },
             {
               url: '/user',
@@ -966,7 +979,7 @@ describe('run', () => {
                   clearInterval(interval);
                 }, timeoutDelayMs);
 
-                return null;
+                return { data: null };
               },
             },
           ],
@@ -1010,7 +1023,7 @@ describe('run', () => {
                   type: 'query',
                   name: 'GetUser',
                   response: ({ context }) => ({
-                    data: { user: { name: context.name } },
+                    data: { data: { user: { name: context.name } } },
                   }),
                 },
                 {
@@ -1020,7 +1033,7 @@ describe('run', () => {
                     updateContext({ name });
 
                     return {
-                      data: { updateUser: { name } },
+                      data: { data: { updateUser: { name } } },
                     };
                   },
                 },
@@ -1083,7 +1096,7 @@ describe('run', () => {
           {
             url: '/test-me',
             method: 'GET',
-            response: expectedInitialResponse,
+            response: { data: expectedInitialResponse },
           },
         ],
         scenarios: {
@@ -1091,7 +1104,7 @@ describe('run', () => {
             {
               url: '/test-me',
               method: 'GET',
-              response: expectedResponse,
+              response: { data: expectedResponse },
             },
           ],
         },
@@ -1136,14 +1149,14 @@ describe('run', () => {
             {
               url: '/test-me',
               method: 'GET',
-              response: expectedResponse1,
+              response: { data: expectedResponse1 },
             },
           ],
           test2: [
             {
               url: '/test-me-2',
               method: 'GET',
-              response: expectedResponse2,
+              response: { data: expectedResponse2 },
             },
           ],
         },
@@ -1170,9 +1183,9 @@ describe('run', () => {
     });
 
     it('GraphQL operations on the same URL are merged', async () => {
-      const expectedResponse1 = { a: 1 };
-      const expectedResponse2 = { b: 2 };
-      const expectedResponse3 = { c: 3 };
+      const expectedResponse1 = { data: { a: 1 } };
+      const expectedResponse2 = { data: { b: 2 } };
+      const expectedResponse3 = { data: { c: 3 } };
       const server = run({
         default: [
           {
@@ -1182,12 +1195,11 @@ describe('run', () => {
               {
                 name: 'Query1',
                 type: 'query',
-                response: expectedResponse1,
+                response: { data: expectedResponse1 },
               },
               {
                 name: 'Query2',
                 type: 'query',
-                response: {},
               },
             ],
           },
@@ -1201,7 +1213,7 @@ describe('run', () => {
                 {
                   name: 'Query2',
                   type: 'query',
-                  response: expectedResponse2,
+                  response: { data: expectedResponse2 },
                 },
               ],
             },
@@ -1214,7 +1226,7 @@ describe('run', () => {
                 {
                   name: 'Query3',
                   type: 'query',
-                  response: expectedResponse3,
+                  response: { data: expectedResponse3 },
                 },
               ],
             },
@@ -1309,7 +1321,7 @@ describe('run', () => {
           {
             url: '/test-me',
             method: 'GET',
-            response: initialResponse,
+            response: { data: initialResponse },
           },
         ],
         scenarios: {
@@ -1317,7 +1329,7 @@ describe('run', () => {
             {
               url: '/test-me',
               method: 'GET',
-              response: scenarioResponse,
+              response: { data: scenarioResponse },
             },
           ],
         },
@@ -1359,7 +1371,7 @@ describe('run', () => {
           {
             url: '/test-me',
             method: 'GET',
-            response: initialResponse,
+            response: { data: initialResponse },
           },
         ],
         scenarios: {
@@ -1367,7 +1379,7 @@ describe('run', () => {
             {
               url: '/test-me',
               method: 'GET',
-              response: scenarioResponse,
+              response: { data: scenarioResponse },
             },
           ],
         },
@@ -1430,7 +1442,9 @@ describe('run', () => {
             {
               url: '/user',
               method: 'GET',
-              response: ({ context }) => context.name,
+              response: ({ context }) => ({
+                data: context.name,
+              }),
             },
           ],
         },
@@ -1472,7 +1486,7 @@ describe('run', () => {
             {
               url: '/info',
               method: 'GET',
-              response: ({ context }) => context,
+              response: ({ context }) => ({ data: context }),
             },
           ],
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,16 +25,12 @@ export type ScenarioMap = {
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-export type Override<TResponse> = {
-  __override: ResponseProps<TResponse>;
-};
-
 export type ResponseFunction<TInput, TResponse> = (
   input: TInput & {
     updateContext: UpdateContext;
     context: Context;
   },
-) => TResponse | Override<TResponse> | Promise<TResponse | Override<TResponse>>;
+) => TResponse | Promise<TResponse>;
 
 export type MockResponse<TInput, TResponse> =
   | TResponse
@@ -42,25 +38,28 @@ export type MockResponse<TInput, TResponse> =
 
 type HttpResponse = Record<string, any> | string | null;
 
-export type ResponseProps<TResponse> = {
-  response?: TResponse;
-  responseCode?: number;
-  responseHeaders?: Record<string, string>;
-  responseDelay?: number;
+export type ResponseProps<TInput, TResponse> = {
+  response?: MockResponse<
+    TInput,
+    {
+      data?: TResponse;
+      status?: number;
+      headers?: Record<string, string>;
+      delay?: number;
+    }
+  >;
 };
 
 export type HttpMock = {
   url: string | RegExp;
   method: HttpMethod;
 } & ResponseProps<
-  MockResponse<
-    {
-      query: Record<string, string | Array<string>>;
-      body: Record<string, any>;
-      params: Record<string, string>;
-    },
-    HttpResponse
-  >
+  {
+    query: Record<string, string | Array<string>>;
+    body: Record<string, any>;
+    params: Record<string, string>;
+  },
+  HttpResponse
 >;
 
 type GraphQlResponse = {
@@ -72,12 +71,10 @@ export type Operation = {
   type: 'query' | 'mutation';
   name: string;
 } & ResponseProps<
-  MockResponse<
-    {
-      variables: Record<string, any>;
-    },
-    GraphQlResponse | HttpResponse
-  >
+  {
+    variables: Record<string, any>;
+  },
+  GraphQlResponse
 >;
 
 export type GraphQlMock = {


### PR DESCRIPTION
API change for responses allow for responses to change some of the data returned without having to use the __override feature (which has subsequently been removed). The operation type has also been cleaned up to only allow GQL responses to be added to the mock (originally it also allowed for HttpResponse). This will now pick up more GQL related errors.

BREAKING CHANGE: The API for response has changed. Now all response related properties are nested under response: status, headers, data and delay. The function version of response has the same requirements.

fix #59