### PR TITLE
chore: increase the file limit for forms

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -63,7 +63,13 @@ function createExpressApp({
   app.use(cors({ credentials: true }));
   app.use(cookieParser());
   app.use(uiPath, express.static(path.join(__dirname, 'assets')));
-  app.use(express.urlencoded({ extended: false }));
+  app.use(
+    express.urlencoded({
+      extended: false,
+      limit: '10mb',
+      parameterLimit: 100000,
+    }),
+  );
   app.use(express.json());
   app.use(express.text({ type: 'application/graphql' }));
 


### PR DESCRIPTION
Update default body parser config to allow image files to be sent.

This is updating the defaults, but is making them more permissive so shouldn't affect existing usage.